### PR TITLE
CI: split test job into engine and upstream Fizzy jobs

### DIFF
--- a/.github/actions/setup-fizzy-app/action.yml
+++ b/.github/actions/setup-fizzy-app/action.yml
@@ -1,0 +1,35 @@
+name: Set up Fizzy app
+description: Install Ruby + system deps, cache bundles, clone Fizzy, migrate
+
+inputs:
+  fizzy_ref:
+    description: "Fizzy git ref for cloning"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: "3.4"
+        bundler-cache: true
+
+    - name: Install system dependencies
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libvips-dev imagemagick libopenslide-dev
+
+    - name: Cache Fizzy bundle
+      uses: actions/cache@v4
+      with:
+        path: test/fizzy/vendor/bundle
+        key: fizzy-bundle-${{ runner.os }}-${{ inputs.fizzy_ref }}-${{ github.run_id }}
+        restore-keys: fizzy-bundle-${{ runner.os }}-${{ inputs.fizzy_ref }}-
+
+    - name: Clone Fizzy and prepare app
+      shell: bash
+      env:
+        FIZZY_REF: ${{ inputs.fizzy_ref }}
+      run: bundle exec rake dev:setup

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -14,12 +14,11 @@ on:
         required: true
 
 jobs:
-  test:
-    name: Run tests
+  engine_tests:
+    name: Run time_tracking engine tests
     runs-on: ubuntu-latest
 
     env:
-      FIZZY_REF: ${{ inputs.fizzy_ref }}
       FIZZY_IMAGE_TAG: ${{ inputs.fizzy_image_tag }}
       BUNDLE_PATH: vendor/bundle
 
@@ -29,29 +28,32 @@ jobs:
         with:
           ref: ${{ inputs.engine_ref || github.ref }}
 
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+      - name: Set up Fizzy app
+        uses: ./.github/actions/setup-fizzy-app
         with:
-          ruby-version: "3.4"
-          bundler-cache: true
+          fizzy_ref: ${{ inputs.fizzy_ref }}
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libvips-dev imagemagick libopenslide-dev
-
-      - name: Cache Fizzy bundle
-        uses: actions/cache@v4
-        with:
-          path: test/fizzy/vendor/bundle
-          key: fizzy-bundle-${{ runner.os }}-${{ env.FIZZY_REF }}-${{ github.run_id }}
-          restore-keys: fizzy-bundle-${{ runner.os }}-${{ env.FIZZY_REF }}-
-
-      - name: Set up Fizzy host app
-        run: bundle exec rake dev:setup
-
-      - name: Run engine tests
+      - name: Run time_tracking engine tests
         run: bundle exec rake test
 
-      - name: Run host tests
+  fizzy_tests:
+    name: Run fizzy app tests
+    runs-on: ubuntu-latest
+
+    env:
+      FIZZY_IMAGE_TAG: ${{ inputs.fizzy_image_tag }}
+      BUNDLE_PATH: vendor/bundle
+
+    steps:
+      - name: Checkout engine
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.engine_ref || github.ref }}
+
+      - name: Set up Fizzy app
+        uses: ./.github/actions/setup-fizzy-app
+        with:
+          fizzy_ref: ${{ inputs.fizzy_ref }}
+
+      - name: Run fizzy app tests
         run: bundle exec rake test:fizzy


### PR DESCRIPTION
## Summary

- Split the single "Run tests" job into two sibling jobs: `engine_tests` (Run time_tracking engine tests) and `fizzy_tests` (Run fizzy app tests). Upstream Fizzy failures now surface as a distinct red job instead of a generic "Run tests failed".
- Extract shared setup (Ruby, system deps, bundle cache, `rake dev:setup`) into a local composite action at `.github/actions/setup-fizzy-app/` so the two jobs stay DRY.
- Motivated by run [24212031140](https://github.com/richardkmichael/fizzy-time_tracking/actions/runs/24212031140), where a bad Fizzy release (`fizzy@e16b52b`) failed the upstream suite and made our CI look broken.

## Test plan

- [x] This PR's CI run shows two parallel jobs: `Run time_tracking engine tests` and `Run fizzy app tests`, both green. Run [24307221837](https://github.com/richardkmichael/fizzy-time_tracking/actions/runs/24307221837) — engine 2m43s, fizzy 3m1s, wall-clock 3m1s (no regression vs. the old single-job ~3m4s).
- [x] Post-merge push run [24307306227](https://github.com/richardkmichael/fizzy-time_tracking/actions/runs/24307306227) (reran after an initial cancellation, see below) — both split jobs ran on `development` and passed.
- [ ] ~~After merge, dispatch `development.yml` with `fizzy_ref=fizzy@e16b52b` — only `Run fizzy app tests` should go red, proving the split actually separates the signals.~~ See "Unexpected findings" below.

## Unexpected findings

### 1. `fizzy@e16b52b` is no longer a reliable reproducer

Post-merge, dispatched `development.yml` with `fizzy_ref=fizzy@e16b52b` (the same ref that failed in run 24212031140) to demonstrate the red/green signal separation. Run [24307315769](https://github.com/richardkmichael/fizzy-time_tracking/actions/runs/24307315769): both jobs passed. The original failure wasn't deterministic — it was a flake.

Likely cause: the failing test was `Notification::PushTarget::WebTest#test_payload_for_triage_falls_back_when_column_name_is_missing`, which errored with `ActiveRecord::RecordInvalid: Validation failed: Endpoint resolves to a private or invalid IP address`. This is SSRF-style validation that does a live DNS lookup on the fixture URL. If the URL's A record drifts (or the GH runner's resolver resolves it differently on different days), the validation flips. Not a test issue in our code and nothing we control.

### 2. Concurrency group cancels back-to-back runs on the same ref

The post-merge push run [24307306227](https://github.com/richardkmichael/fizzy-time_tracking/actions/runs/24307306227) was cancelled 33s in by the `fizzy@e16b52b` dispatch run that followed. Cause: `development.yml` has `concurrency: group: development-${{ github.ref }}` with `cancel-in-progress: true`. Both runs had `github.ref = refs/heads/development`, so they collided and the later dispatch cancelled the earlier push. Reran the cancelled push manually and it went green — so the structural evidence on `development` is now in place.

Takeaway: when invoking `workflow_dispatch` on `development.yml` immediately after a push to `development`, be aware that the concurrency group will cancel whichever is in-progress.

### Implications for future work in this area

- Do not assume `fizzy@e16b52b` is a reliable reproducer — it's currently passing.
- The structural split is correct and verified on both the PR branch and `development`. The signal-separation promise (red fizzy job, green engine job) is unverified on a live failure and will be observed organically the next time upstream Fizzy breaks its own suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)